### PR TITLE
fix: options not updated in tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Self explanatory. Skips the intro cutscene when starting the game.
 
 ## Credits
 
-Winch was originally made by [Hacktix](https://github.com/Hacktix), this project is based off the [original repo](https://github.com/Hacktix/Winch).
+Winch was originally made by [Hacktix](https://github.com/Ashiepaws), this project is based off the [original repo](https://github.com/Ashiepaws/Winch).
 
 Authors:
 - [xen-42](https://github.com/xen-42)

--- a/Winch/Core/ModAssembly.cs
+++ b/Winch/Core/ModAssembly.cs
@@ -31,9 +31,9 @@ public class ModAssembly
     public string Preload => Metadata.ContainsKey("Preload") ? Metadata["Preload"].ToString() : string.Empty;
     public string Entrypoint => Metadata.ContainsKey("Entrypoint") ? Metadata["Entrypoint"].ToString() : string.Empty;
     public bool ApplyPatches => Metadata.ContainsKey("ApplyPatches") && (bool)Metadata["ApplyPatches"];
-    public ModConfig? Config => ModConfig.TryGetConfig(BasePathFolderName, out var config) ? config : null;
-    public bool DefaultConfig => ModConfig.HasDefaultConfig(BasePathFolderName);
-    public ModConfig GetConfig() => ModConfig.GetConfig(BasePathFolderName);
+    public ModConfig? Config => ModConfig.TryGetConfig(GUID, out var config) ? config : null;
+    public bool DefaultConfig => ModConfig.HasDefaultConfig(GUID);
+    public ModConfig GetConfig() => ModConfig.GetConfig(GUID);
 
     private ModAssembly(string basePath) {
         BasePath = basePath;


### PR DESCRIPTION
It was updated in the config file but not in the game's mod tabs.

It's because the addConfigInput (ModsTabs:330) was getting the config from the mod's GUID, while the ModAssembly class was using the Base path (ModAssembly:34-36) (that can be different from the game's guid).

#46 