### PR TITLE
0.6.2

### DIFF
--- a/Winch.Examples/ExampleItems/Assets/POI/Harvest/exampleitems.examplevanillaharvestpoi.json
+++ b/Winch.Examples/ExampleItems/Assets/POI/Harvest/exampleitems.examplevanillaharvestpoi.json
@@ -1,0 +1,13 @@
+{
+    "location": {
+        "x": 415.0,
+        "y": 0.0,
+        "z": -260.0
+    },
+    "harvestableParticlePrefab": "MediumRoundFishParticles",
+    "items": [ "cod" ],
+    "startStock": 5,
+    "maxStock": 10,
+    "doesRestock": true,
+    "usesTimeSpecificStock": false
+}

--- a/Winch.Examples/ExampleItems/ExampleConfig.cs
+++ b/Winch.Examples/ExampleItems/ExampleConfig.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Winch.Util;
+
+namespace ExampleItems;
+
+[JsonObject]
+public class ExampleConfig
+{
+    public bool Toggle = true; // "toggle" type
+    public string Text = "Hello"; // "text" type
+    public int Integer = 22; // "integer" type. Can be byte, short, int, long, sbyte, ushort, uint, or ulong
+    public decimal Decimal = 1.01m; // "decimal" or "number" type. Can be float, double, or decimal
+    public float Slider = 15; // "slider" type. Must be float
+    public ExampleEnum Dropdown = ExampleEnum.Two; // "dropdown" type. Can be a string or an enum
+    public DredgeColorTypeEnum Color = DredgeColorTypeEnum.NEUTRAL; // "color" type. Must be the DredgeColorTypeEnum enum.
+
+    [JsonConverter(typeof(CustomStringEnumConverter))]
+    public enum ExampleEnum
+    {
+        One,
+        Two,
+        Three
+    }
+}

--- a/Winch.Examples/ExampleItems/Loader.cs
+++ b/Winch.Examples/ExampleItems/Loader.cs
@@ -17,14 +17,20 @@ public static class Loader
     public static ModConfig ModConfig => ModConfig.GetConfig();
     public static ExampleConfig Config;
 
-    public static string BasePath => ModAssemblyLoader.GetCurrentMod().BasePath;
+
+    public static ModAssembly ModAssembly => ModAssemblyLoader.GetCurrentMod();
+    public static string BasePath => ModAssembly.BasePath;
+    public static string GUID => ModAssembly.GUID;
+
 
     public static ExampleSaveParticipant Participant = ExampleSaveParticipant.Instance;
 
     public static ExampleRecipeData exampleRecipeData;
 
+
     public static ItemData MilkBucket => ItemUtil.GetModdedItemData("exampleitems.milk");
     public static VibrationData MilkBucketVibrationData => VibrationUtil.GetModdedVibrationData("exampleitems.milk");
+
 
     public static void Initialize()
     {

--- a/Winch.Examples/ExampleItems/Loader.cs
+++ b/Winch.Examples/ExampleItems/Loader.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.AI;
-using UnityEngine.UI;
 using Winch.Config;
 using Winch.Core;
 using Winch.Data.Shop;
@@ -240,8 +239,13 @@ public static class Loader
         gridShopJunk.gridConfiguration.mainItemSubtype |= ExampleEnums.ItemSubtypes.EXAMPLE;
         gridShopJunk.Reinit();
 
+        // Add a subtype to a grid
+        var gridShipwrightJunk = GameManager.Instance.SaveData.GetGridByKey(GridKey.SHIPWRIGHT_MATERIALS);
+        gridShipwrightJunk.gridConfiguration.mainItemSubtype |= ExampleEnums.ItemSubtypes.EXAMPLE;
+        gridShipwrightJunk.Reinit();
+
         // Add a subtype to a market/shipyard
-        var junkShipyards = DockUtil.GetAllShipyardDestinations().Where(shipyard => shipyard.marketTabs.Any(marketTab => marketTab.gridKey == GridKey.TRAVELLING_MERCHANT_MATERIALS));
+        var junkShipyards = DockUtil.GetAllShipyardDestinations().Where(shipyard => shipyard.marketTabs.Any(marketTab => marketTab.gridKey == GridKey.TRAVELLING_MERCHANT_MATERIALS || marketTab.gridKey == GridKey.SHIPWRIGHT_MATERIALS));
         foreach (var junkShipyard in junkShipyards)
         {
             junkShipyard.itemSubtypesBought |= ExampleEnums.ItemSubtypes.EXAMPLE;

--- a/Winch.Examples/ExampleItems/Loader.cs
+++ b/Winch.Examples/ExampleItems/Loader.cs
@@ -1,8 +1,9 @@
 using System;
-using Google.Protobuf.WellKnownTypes;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.AI;
+using UnityEngine.UI;
+using Winch.Config;
 using Winch.Core;
 using Winch.Data.Shop;
 using Winch.Util;
@@ -12,6 +13,10 @@ namespace ExampleItems;
 
 public static class Loader
 {
+    // Automatically gets your mod's config
+    public static ModConfig ModConfig => ModConfig.GetConfig();
+    public static ExampleConfig Config;
+
     public static string BasePath => ModAssemblyLoader.GetCurrentMod().BasePath;
 
     public static ExampleSaveParticipant Participant = ExampleSaveParticipant.Instance;
@@ -23,11 +28,19 @@ public static class Loader
 
     public static void Initialize()
     {
+        // Config
+        RefreshConfig(); // First grab of config
+        ModConfig.OnConfigChanged += ModConfig_OnConfigChanged;
+        ModConfig.OnConfigValueChanged += ModConfig_OnConfigValueChanged; // This always runs after OnConfigChanged
+
+        // Saves
         SaveUtil.RegisterDataParticipant(Participant);
         new GameObject(nameof(ExampleSaveBehaviour)).AddComponent<ExampleSaveBehaviour>();
 
+        // Recipe Data
         exampleRecipeData = ScriptableObject.CreateInstance<ExampleRecipeData>().DontDestroyOnLoad();
 
+        // Harvestable Particle Prefabs
         PoiUtil.AddModdedHarvestableParticlePrefab("MinecraftClownfishParticles", AssetBundleUtil.GetPrefab("exampleitems.bundle", "MinecraftClownfishParticles"));
         PoiUtil.AddModdedHarvestableParticlePrefab("MinecraftCodParticles", AssetBundleUtil.GetPrefab("exampleitems.bundle", "MinecraftCodParticles"));
         PoiUtil.AddModdedHarvestableParticlePrefab("MinecraftCodParticlesOriginal", AssetBundleUtil.GetPrefab("exampleitems.bundle", "MinecraftCodParticlesOriginal"));
@@ -89,10 +102,72 @@ public static class Loader
         #endregion
         #endregion
 
+        // Game Events
         ApplicationEvents.Instance.OnGameLoaded += OnGameLoaded;
         GameManager.Instance.OnGameStarted += OnGameStarted;
         GameManager.Instance.OnGameEnded += OnGameEnded;
     }
+
+    #region Config
+    public static void RefreshConfig()
+    {
+        var oldConfig = Config;
+        Config = ModConfig.ToObject<ExampleConfig>(); // Get the config as your custom class
+    }
+
+    private static void ModConfig_OnConfigChanged()
+    {
+        RefreshConfig();
+        // Do thing when any value changes
+    }
+
+    private static void ModConfig_OnConfigValueChanged(string key)
+    {
+        try
+        {
+            switch (key)
+            {
+                // either use nameof(ExampleConfig.Property) or just the string "Property"
+                case nameof(ExampleConfig.Toggle):
+                    // Do thing when just one value changes
+                    if (Config.Toggle)
+                    {
+                        WinchCore.Log.Info("Toggle was enabled");
+                    }
+                    else
+                    {
+                        WinchCore.Log.Info("Toggle was disabled");
+                    }
+                    break;
+                case nameof(ExampleConfig.Text):
+                    WinchCore.Log.Info($"Text was set to \"{Config.Text}\"");
+                    break;
+                case nameof(ExampleConfig.Integer):
+                    WinchCore.Log.Info($"Integer was set to \"{Config.Integer}\"");
+                    break;
+                case nameof(ExampleConfig.Decimal):
+                    WinchCore.Log.Info($"Decimal was set to \"{Config.Decimal}\"");
+                    break;
+                case nameof(ExampleConfig.Slider):
+                    WinchCore.Log.Info($"Slider was set to \"{Config.Slider}\"");
+                    break;
+                case nameof(ExampleConfig.Dropdown):
+                    WinchCore.Log.Info($"Dropdown was set to \"{Config.Dropdown}\"");
+                    break;
+                case nameof(ExampleConfig.Color):
+                    WinchCore.Log.Info($"Color was set to \"{Config.Color}\"");
+                    break;
+                default:
+                    WinchCore.Log.Info($"{key} was changed");
+                    break;
+            }
+        }
+        catch (System.Exception ex)
+        {
+            WinchCore.Log.Error(ex.ToString());
+        }
+    }
+    #endregion
 
     private static GameObject CreateCube()
     {

--- a/Winch.Examples/ExampleItems/mod_meta.json
+++ b/Winch.Examples/ExampleItems/mod_meta.json
@@ -2,7 +2,7 @@
 	"Name": "Example Items",
 	"Author": "Hacktix",
 	"ModGUID": "hacktix.exampleitems",
-	"Version": "2.0.1",
+	"Version": "2.0.2",
 	"ModAssembly": "ExampleItems.dll",
 	"Entrypoint": "ExampleItems.Loader/Initialize",
 	"MinWinchVersion": "0.5.0"

--- a/Winch.Examples/IntroSkipper/mod_meta.json
+++ b/Winch.Examples/IntroSkipper/mod_meta.json
@@ -1,5 +1,6 @@
 {
 	"Name": "Intro Skipper",
+	"Author": "Hacktix",
 	"ModGUID": "hacktix.introskipper",
 	"Version": "1.0.1",
 	"ModAssembly": "IntroSkipper.dll",

--- a/Winch/Assets/Localization/en.json
+++ b/Winch/Assets/Localization/en.json
@@ -6,6 +6,7 @@
 	"settings.tab.mods": "Mods",
 	"settings.mods.footer.list": "List",
 	"settings.mods.footer.options": "Options",
+	"title.shipwright-materials": "Shipwright - Miscellaneous",
 	"winch.name": "Winch",
 	"winch.writelogstofile.title": "Write logs to file",
 	"winch.writelogstofile.tooltip": "Whether to write logs to a file.\n\nREQUIRES RESTART TO TAKE EFFECT.",

--- a/Winch/Assets/Localization/en.json
+++ b/Winch/Assets/Localization/en.json
@@ -19,7 +19,7 @@
 	"winch.detailedlogsources.title": "Detailed Log Sources",
 	"winch.detailedlogsources.tooltip": "Whether to show the class and method the log came from instead of just the assembly name.",
 	"winch.enabledeveloperconsole.title": "Enable Developer Console",
-	"winch.enabledeveloperconsole.tooltip": "Whether to enable the terminal that can opened with the ` key.",
+	"winch.enabledeveloperconsole.tooltip": "Whether to enable the terminal that can opened with the ` key (or R1 + R2 + L1 + L2 on controllers).",
 	"winch.maxlogfiles.title": "Max Log Files",
 	"winch.maxlogfiles.tooltip": "The maximum amount of logs that can be in the log folder.\n\nREQUIRES RESTART TO TAKE EFFECT.",
 	"winch.exportyarnprogram.title": "Export Yarn Program",

--- a/Winch/Assets/Shops/Shipwright_Junk.json
+++ b/Winch/Assets/Shops/Shipwright_Junk.json
@@ -1,0 +1,4 @@
+﻿{
+    "gridKey": "SHIPWRIGHT_MATERIALS",
+    "alwaysInStock": [ ]
+}

--- a/Winch/Components/FieldInput.cs
+++ b/Winch/Components/FieldInput.cs
@@ -202,7 +202,7 @@ public class FieldInput : Input, ISubmitHandler, IEventSystemHandler
         OnFocusChanged(false);
     }
 
-    public virtual void ForceSliderDeselect()
+    public virtual void ForceDeselect()
     {
         inputField.interactable = false;
         EventSystem.current.SetSelectedGameObject(gameObject);

--- a/Winch/Components/SliderInput.cs
+++ b/Winch/Components/SliderInput.cs
@@ -100,7 +100,7 @@ public class SliderInput : Input, ISubmitHandler, IEventSystemHandler
         OnSliderFocusChanged(false);
     }
 
-    public virtual void ForceSliderDeselect()
+    public virtual void ForceDeselect()
     {
         slider.interactable = false;
         EventSystem.current.SetSelectedGameObject(gameObject);

--- a/Winch/Core/Initializer.cs
+++ b/Winch/Core/Initializer.cs
@@ -135,7 +135,7 @@ class Initializer
 
     private static void InitializeWinchBehaviour()
     {
-        UnityEngine.Object.DontDestroyOnLoad(new GameObject("Winch", typeof(WinchBehaviour)));
+        UnityEngine.Object.DontDestroyOnLoad(new GameObject(Constants.WinchTitle, typeof(WinchBehaviour)));
     }
 
     internal static void InitializeVersionLabel()

--- a/Winch/Core/ModAssembly.cs
+++ b/Winch/Core/ModAssembly.cs
@@ -123,9 +123,43 @@ public class ModAssembly
         foreach (string dep in deps)
         {
             WinchCore.Log.Debug($"Processing dependency {dep}");
+
+            if (string.IsNullOrWhiteSpace(dep))
+            {
+                WinchCore.Log.Error($"Empty dependency entry in mod {GUID}");
+                ModAssemblyLoader.ErrorMods.Add(GUID);
+                continue;
+            }
+
             string depName = dep.Contains("@") ? dep.Split('@')[0] : dep;
             string? depVersion = dep.Contains("@") ? dep.Split('@')[1] : null;
-            if (!ModAssemblyLoader.ExecuteModAssembly(depName, depVersion))
+
+            WinchCore.Log.Debug($"Dependency name: '{depName}', min version: ({depVersion ?? "any"})");
+
+            if (string.IsNullOrWhiteSpace(depName))
+            {
+                WinchCore.Log.Error($"Malformed dependency '{dep}' in mod {GUID}");
+                ModAssemblyLoader.ErrorMods.Add(GUID);
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(depVersion))
+            {
+                WinchCore.Log.Warn($"No minimum version specified for dependency '{depName}' in mod {GUID}. Will attempt to load any version of the dependency, but this may cause version conflicts. Specify by appending '@<version>' to the dependency name in mod_meta.json.");
+            }
+
+            bool executed;
+            try
+            {
+                executed = ModAssemblyLoader.ExecuteModAssembly(depName, depVersion);
+            }
+            catch (Exception ex)
+            {
+                WinchCore.Log.Error($"Failed to execute dependency '{dep}' for mod {GUID}: {ex}");
+                executed = false;
+            }
+
+            if (!executed)
                 ModAssemblyLoader.ErrorMods.Add(GUID);
         }
     }

--- a/Winch/Core/ModAssembly.cs
+++ b/Winch/Core/ModAssembly.cs
@@ -31,9 +31,9 @@ public class ModAssembly
     public string Preload => Metadata.ContainsKey("Preload") ? Metadata["Preload"].ToString() : string.Empty;
     public string Entrypoint => Metadata.ContainsKey("Entrypoint") ? Metadata["Entrypoint"].ToString() : string.Empty;
     public bool ApplyPatches => Metadata.ContainsKey("ApplyPatches") && (bool)Metadata["ApplyPatches"];
-    public ModConfig? Config => ModConfig.TryGetConfig(BasePathFolderName, out var config) ? config : null;
-    public bool DefaultConfig => ModConfig.HasDefaultConfig(BasePathFolderName);
-    public ModConfig GetConfig() => ModConfig.GetConfig(BasePathFolderName);
+    public ModConfig? Config => ModConfig.TryGetConfig(GUID, out var config) ? config : null;
+    public bool DefaultConfig => ModConfig.HasDefaultConfig(GUID);
+    public ModConfig GetConfig() => ModConfig.GetConfig(GUID);
 
     private ModAssembly(string basePath) {
         BasePath = basePath;

--- a/Winch/Core/ModAssembly.cs
+++ b/Winch/Core/ModAssembly.cs
@@ -82,7 +82,7 @@ public class ModAssembly
         _guid = GetRequiredMetadataString("ModGUID");
         _assemblyRelativePath = GetRequiredMetadataString("ModAssembly");
         _name = GetRequiredMetadataString("Name").Spaced();
-        _author = GetRequiredMetadataString("Author");
+        _author = GetRecommendedMetadataString("Author");
         _version = GetRequiredMetadataString("Version");
         _minWinchVersion = GetMetadataString("MinWinchVersion");
         _dependencies = GetMetadataStringArray("Dependencies");
@@ -97,6 +97,16 @@ public class ModAssembly
     private string GetRequiredMetadataString(string key)
     {
         return GetMetadataString(key) ?? throw new MissingFieldException($"Required metadata field '{key}' is missing or empty in {Constants.ModManifestFileName} for '{BasePathFolderName}'.");
+    }
+
+    private string GetRecommendedMetadataString(string key)
+    {
+        var value = GetMetadataString(key);
+
+        if (string.IsNullOrWhiteSpace(value))
+            WinchCore.Log.Warn($"Required metadata field '{key}' is missing or empty in {Constants.ModManifestFileName} for '{BasePathFolderName}'.");
+
+        return value;
     }
 
     private string GetMetadataString(string key)

--- a/Winch/Core/ModAssembly.cs
+++ b/Winch/Core/ModAssembly.cs
@@ -44,6 +44,8 @@ public class ModAssembly
 
         string metaText = File.ReadAllText(metaPath);
         Metadata = JsonConvert.DeserializeObject<Dictionary<string, object>>(metaText) ?? throw new InvalidOperationException("Unable to parse mod_meta.json file.");
+
+        ModConfig.RegisterBasePath(GUID, BasePath);
     }
 
     internal static ModAssembly FromPath(string path)

--- a/Winch/Core/ModAssembly.cs
+++ b/Winch/Core/ModAssembly.cs
@@ -99,17 +99,19 @@ public class ModAssembly
             throw new MissingFieldException("No 'ModGUID' field found in Mod Metadata.");
 
         string minVer = MinWinchVersion;
+        string winchVer = VersionUtil.GetVersion();
+
         if (minVer.IsNullOrWhitespace())
-            WinchCore.Log.Warn($"No MinWinchVersion defined. Mod will load anyway, but version conflicts may occur!");
+            WinchCore.Log.Warn($"No MinWinchVersion defined for mod {GUID}. Current Winch version is ({winchVer}). Mod will load anyway, but version conflicts may occur!");
         else
         {
-            string winchVer = VersionUtil.GetVersion();
-
             if (!VersionUtil.ValidateVersion(minVer))
-                throw new FormatException("MinWinchVersion not in correct format.");
+                throw new FormatException($"MinWinchVersion ({minVer}) not in correct format for mod {GUID}.");
+
+            WinchCore.Log.Debug($"Mod {GUID} requires Winch version ({minVer}) or newer. Current Winch version is ({winchVer}).");
 
             if (!VersionUtil.IsSameOrNewer(winchVer, minVer))
-                throw new Exception($"Mod requires a version ({minVer}) of Winch higher than the one installed  ({winchVer}).");
+                throw new Exception($"Mod {GUID} requires Winch version ({minVer}) or newer, but the current Winch version is ({winchVer}). Please update Winch or the mod.");
         }
     }
 

--- a/Winch/Core/ModAssembly.cs
+++ b/Winch/Core/ModAssembly.cs
@@ -4,6 +4,7 @@ using Sirenix.Utilities;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using Winch.Config;
 using Winch.Util;
@@ -13,24 +14,38 @@ namespace Winch.Core;
 public class ModAssembly
 {
     public readonly string BasePath;
-    public Dictionary<string, object> Metadata { get; private set; }
     public Assembly? LoadedAssembly { get; private set; }
+
+    private readonly Dictionary<string, object> _metadata;
+
+    // Cached metadata fields to avoid repeated dictionary lookups
+    private readonly string _guid;
+    private readonly string _assemblyRelativePath;
+    private readonly string _name;
+    private readonly string _author;
+    private readonly string _version;
+    private readonly string _minWinchVersion;
+    private readonly string[] _dependencies;
+    private readonly string[] _conflicts;
+    private readonly string _preload;
+    private readonly string _entrypoint;
+    private readonly bool _applyPatches;
 
     public string AssetsPath => Path.Combine(BasePath, "Assets");
     public string AssemblyName => LoadedAssembly != null ? LoadedAssembly.GetName().Name : string.Empty;
     public string BasePathFolderName => Path.GetFileName(BasePath);
-    public string GUID => Metadata.ContainsKey("ModGUID") ? Metadata["ModGUID"].ToString() : throw new MissingFieldException("No 'ModGUID' field found in Mod Metadata.");
-    public string AssemblyRelativePath => Metadata.ContainsKey("ModAssembly") ? Metadata["ModAssembly"].ToString() : throw new MissingFieldException("Property 'ModAssembly' not found in mod_meta.json");
-    public string Name => Metadata.ContainsKey("Name") ? Metadata["Name"].ToString().Spaced() : string.Empty;
-    public string CleanedUpName => Name.Replace("Dredge ", "").Replace("DREDGE ", "").Replace("D R E D G E ", "").Trim();
-    public string Author => Metadata.ContainsKey("Author") ? Metadata["Author"].ToString() : string.Empty;
-    public string Version => Metadata.ContainsKey("Version") ? Metadata["Version"].ToString() : throw new MissingFieldException("No 'Version' field found in Mod Metadata.");
-    public string MinWinchVersion => Metadata.ContainsKey("MinWinchVersion") ? Metadata["MinWinchVersion"].ToString() : string.Empty;
-    public string[] Dependencies => Metadata.ContainsKey("Dependencies") ? (((JArray)Metadata["Dependencies"]).ToObject<string[]>() ?? Array.Empty<string>()) : Array.Empty<string>();
-    public string[] Conflicts => Metadata.ContainsKey("Conflicts") ? (((JArray)Metadata["Conflicts"]).ToObject<string[]>() ?? Array.Empty<string>()) : Array.Empty<string>();
-    public string Preload => Metadata.ContainsKey("Preload") ? Metadata["Preload"].ToString() : string.Empty;
-    public string Entrypoint => Metadata.ContainsKey("Entrypoint") ? Metadata["Entrypoint"].ToString() : string.Empty;
-    public bool ApplyPatches => Metadata.ContainsKey("ApplyPatches") && (bool)Metadata["ApplyPatches"];
+    public string GUID => _guid;
+    public string AssemblyRelativePath => _assemblyRelativePath;
+    public string Name => _name;
+    public string CleanedUpName => _name.Replace("Dredge ", "").Replace("DREDGE ", "").Replace("D R E D G E ", "").Trim();
+    public string Author => _author;
+    public string Version => _version;
+    public string MinWinchVersion => _minWinchVersion;
+    public string[] Dependencies => _dependencies;
+    public string[] Conflicts => _conflicts;
+    public string Preload => _preload;
+    public string Entrypoint => _entrypoint;
+    public bool ApplyPatches => _applyPatches;
     public ModConfig? Config => ModConfig.TryGetConfig(GUID, out var config) ? config : null;
     public bool DefaultConfig => ModConfig.HasDefaultConfig(GUID);
     public ModConfig GetConfig() => ModConfig.GetConfig(GUID);
@@ -40,12 +55,118 @@ public class ModAssembly
 
         string metaPath = Path.Combine(basePath, "mod_meta.json");
         if (!File.Exists(metaPath))
-            throw new FileNotFoundException("Missing mod_meta.json file.");
+            throw new FileNotFoundException($"Missing mod_meta.json file at '{basePath}'.");
 
         string metaText = File.ReadAllText(metaPath);
-        Metadata = JsonConvert.DeserializeObject<Dictionary<string, object>>(metaText) ?? throw new InvalidOperationException("Unable to parse mod_meta.json file.");
+        _metadata = JsonConvert.DeserializeObject<Dictionary<string, object>>(metaText) ?? throw new InvalidOperationException($"Unable to parse mod_meta.json file at '{basePath}'.");
 
-        ModConfig.RegisterBasePath(GUID, BasePath);
+        // Normalize JToken/JValue entries so downstream lookups are simpler
+        var keys = _metadata.Keys.ToArray();
+        foreach (var k in keys)
+        {
+            if (_metadata[k] is JToken token)
+            {
+                try
+                {
+                    _metadata[k] = token.Type == JTokenType.Array ? token : token.ToObject<object>() ?? token;
+                }
+                catch
+                {
+                    _metadata[k] = token;
+                }
+            }
+        }
+
+        // Cache commonly used metadata values to avoid repeated dictionary access
+        _guid = GetRequiredMetadataString("ModGUID");
+        _assemblyRelativePath = GetRequiredMetadataString("ModAssembly");
+        _name = GetRequiredMetadataString("Name").Spaced();
+        _author = GetRequiredMetadataString("Author");
+        _version = GetRequiredMetadataString("Version");
+        _minWinchVersion = GetMetadataString("MinWinchVersion");
+        _dependencies = GetMetadataStringArray("Dependencies");
+        _conflicts = GetMetadataStringArray("Conflicts");
+        _preload = GetMetadataString("Preload");
+        _entrypoint = GetMetadataString("Entrypoint");
+        _applyPatches = GetMetadataBool("ApplyPatches");
+
+        ModConfig.RegisterBasePath(_guid, BasePath);
+    }
+
+    private string GetRequiredMetadataString(string key)
+    {
+        return GetMetadataString(key) ?? throw new MissingFieldException($"Required metadata field '{key}' is missing or empty in mod_meta.json for '{BasePathFolderName}'.");
+    }
+
+    private string GetMetadataString(string key)
+    {
+        var value = GetMetadata<string>(key);
+
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        return value;
+    }
+
+    private string[] GetMetadataStringArray(string key)
+    {
+        return GetMetadataWithDefault(key, Array.Empty<string>());
+    }
+
+    private bool GetMetadataBool(string key)
+    {
+        return GetMetadataWithDefault(key, false);
+    }
+
+    private int GetMetadataInt(string key)
+    {
+        return GetMetadataWithDefault(key, 0);
+    }
+
+    private double GetMetadataDouble(string key)
+    {
+        return GetMetadataWithDefault(key, 0);
+    }
+
+    private T GetMetadataWithDefault<T>(string key, T defaultValue)
+    {
+        return GetMetadata<T>(key) ?? defaultValue;
+    }
+
+    private T? GetMetadata<T>(string key)
+    {
+        if (!_metadata.TryGetValue(key, out var raw) || raw == null)
+            return default;
+
+        // If the raw value is already the target type, return it
+        if (raw is T t)
+            return t;
+
+        // Handle JToken conversions
+        if (raw is JToken jt)
+        {
+            try { return jt.ToObject<T>(); } catch { return default; }
+        }
+
+        try
+        {
+            // Attempt JSON round-trip for complex conversions
+            var json = JsonConvert.SerializeObject(raw);
+            return JsonConvert.DeserializeObject<T>(json);
+        }
+        catch
+        {
+            try
+            {
+                // Final fallback: attempt direct conversion
+                return (T)Convert.ChangeType(raw, typeof(T));
+            }
+            catch
+            {
+                // If all conversions fail, return defaults
+                return default;
+            }
+        }
     }
 
     internal static ModAssembly FromPath(string path)
@@ -63,13 +184,26 @@ public class ModAssembly
 
         CheckCompatibility();
 
-        LoadedAssembly = Assembly.LoadFrom(assemblyPath);
-
-        WinchCore.Log.Debug($"Loaded Assembly '{LoadedAssembly.GetName().Name}'.");
-
-        if (Metadata.ContainsKey("Preload"))
+        try
         {
-            ProcessPreload();
+            LoadedAssembly = Assembly.LoadFrom(assemblyPath);
+            WinchCore.Log.Debug($"Loaded Assembly '{LoadedAssembly?.GetName().Name}' for mod '{GUID}'.");
+        }
+        catch (Exception ex)
+        {
+            throw new Exception($"Failed to load assembly for mod '{GUID}' from path '{assemblyPath}'", ex);
+        }
+
+        if (!string.IsNullOrEmpty(Preload))
+        {
+            try
+            {
+                ProcessPreload();
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Preload failed for mod '{GUID}'", ex);
+            }
         }
     }
 
@@ -80,13 +214,13 @@ public class ModAssembly
 
         WinchCore.Log.Debug($"Initializing ModAssembly {LoadedAssembly.GetName().Name}...");
 
-        if (Metadata.ContainsKey("Dependencies"))
+        if (Dependencies.Length > 0)
             ProcessDependencies();
 
-        if (Metadata.ContainsKey("Conflicts"))
+        if (Conflicts.Length > 0)
             ProcessConflicts();
 
-        if (Metadata.ContainsKey("Entrypoint"))
+        if (!string.IsNullOrEmpty(Entrypoint))
             ProcessEntrypoint();
     }
 
@@ -131,8 +265,9 @@ public class ModAssembly
                 continue;
             }
 
-            string depName = dep.Contains("@") ? dep.Split('@')[0] : dep;
-            string? depVersion = dep.Contains("@") ? dep.Split('@')[1] : null;
+            var parts = dep.Split(new[] { '@' }, 2);
+            string depName = parts.Length > 0 ? parts[0] : string.Empty;
+            string? depVersion = parts.Length > 1 ? parts[1] : null;
 
             WinchCore.Log.Debug($"Dependency name: '{depName}', min version: ({depVersion ?? "any"})");
 
@@ -148,7 +283,7 @@ public class ModAssembly
                 WinchCore.Log.Warn($"No minimum version specified for dependency '{depName}' in mod {GUID}. Will attempt to load any version of the dependency, but this may cause version conflicts. Specify by appending '@<version>' to the dependency name in mod_meta.json.");
             }
 
-            bool executed;
+            bool executed = false;
             try
             {
                 executed = ModAssemblyLoader.ExecuteModAssembly(depName, depVersion);
@@ -156,7 +291,6 @@ public class ModAssembly
             catch (Exception ex)
             {
                 WinchCore.Log.Error($"Failed to execute dependency '{dep}' for mod {GUID}: {ex}");
-                executed = false;
             }
 
             if (!executed)
@@ -178,22 +312,31 @@ public class ModAssembly
         }
     }
 
+    private static readonly BindingFlags AnyStatic = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+
     private void ProcessEntrypoint()
     {
         string entrypointSetting = Entrypoint;
         if (!entrypointSetting.Contains("/"))
             throw new ArgumentException("Malformed Entrypoint in mod_meta.json");
 
-        string entrypointTypeName = entrypointSetting.Split('/')[0];
-        string entrypointMethodName = entrypointSetting.Split('/')[1];
+        var parts = entrypointSetting.Split(new[] { '/' }, 2);
+        string entrypointTypeName = parts[0];
+        string entrypointMethodName = parts.Length > 1 ? parts[1] : string.Empty;
 
         Type entrypointType = LoadedAssembly?.GetType(entrypointTypeName) ??
                               throw new EntryPointNotFoundException($"Could not find type {entrypointTypeName} in Mod Assembly");
-        MethodInfo entrypoint = entrypointType.GetMethod(entrypointMethodName) ??
-                                throw new EntryPointNotFoundException($"Could not find method {entrypointTypeName} in type {entrypointTypeName} in Mod Assembly");
+
+        var method = entrypointType.GetMethod(entrypointMethodName, AnyStatic);
+        if (method == null)
+            throw new EntryPointNotFoundException($"Could not find method {entrypointMethodName} in type {entrypointTypeName} in Mod Assembly");
+
+        if (method.GetParameters().Length > 0)
+            throw new EntryPointNotFoundException($"Entrypoint method {entrypointMethodName} in {entrypointTypeName} must take no parameters");
 
         WinchCore.Log.Debug($"Invoking entrypoint {entrypointType}.{entrypointMethodName}...");
-        entrypoint.Invoke(null, new object[0]);
+        try { method.Invoke(null, Array.Empty<object>()); }
+        catch (TargetInvocationException tie) { throw tie.InnerException ?? tie; }
     }
 
     private void ProcessPreload()
@@ -202,16 +345,23 @@ public class ModAssembly
         if (!preloadSetting.Contains("/"))
             throw new ArgumentException("Malformed Preload in mod_meta.json");
 
-        string preloadTypeName = preloadSetting.Split('/')[0];
-        string preloadMethodName = preloadSetting.Split('/')[1];
+        var parts = preloadSetting.Split(new[] { '/' }, 2);
+        string preloadTypeName = parts[0];
+        string preloadMethodName = parts.Length > 1 ? parts[1] : string.Empty;
 
         Type preloaderType = LoadedAssembly?.GetType(preloadTypeName) ??
                              throw new EntryPointNotFoundException($"Could not find type {preloadTypeName} in Mod Assembly");
-        MethodInfo preloader = preloaderType.GetMethod(preloadMethodName) ??
-                               throw new EntryPointNotFoundException($"Could not find method {preloadTypeName} in type {preloadTypeName} in Mod Assembly");
+
+        var method = preloaderType.GetMethod(preloadMethodName, AnyStatic);
+        if (method == null)
+            throw new EntryPointNotFoundException($"Could not find method {preloadMethodName} in type {preloadTypeName} in Mod Assembly");
+
+        if (method.GetParameters().Length > 0)
+            throw new EntryPointNotFoundException($"Preload method {preloadMethodName} in {preloadTypeName} must take no parameters");
 
         WinchCore.Log.Debug($"Invoking preloader {preloaderType}.{preloadMethodName}...");
-        preloader.Invoke(null, new object[0]);
+        try { method.Invoke(null, Array.Empty<object>()); }
+        catch (TargetInvocationException tie) { throw tie.InnerException ?? tie; }
     }
 
     public override string ToString() => GUID;

--- a/Winch/Core/ModAssembly.cs
+++ b/Winch/Core/ModAssembly.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using Winch.Config;
 using Winch.Util;
+using Winch;
 
 namespace Winch.Core;
 
@@ -53,12 +54,12 @@ public class ModAssembly
     private ModAssembly(string basePath) {
         BasePath = basePath;
 
-        string metaPath = Path.Combine(basePath, "mod_meta.json");
+        string metaPath = Path.Combine(basePath, Constants.ModManifestFileName);
         if (!File.Exists(metaPath))
-            throw new FileNotFoundException($"Missing mod_meta.json file at '{basePath}'.");
+            throw new FileNotFoundException($"Missing {Constants.ModManifestFileName} file at '{basePath}'.");
 
         string metaText = File.ReadAllText(metaPath);
-        _metadata = JsonConvert.DeserializeObject<Dictionary<string, object>>(metaText) ?? throw new InvalidOperationException($"Unable to parse mod_meta.json file at '{basePath}'.");
+        _metadata = JsonConvert.DeserializeObject<Dictionary<string, object>>(metaText) ?? throw new InvalidOperationException($"Unable to parse {Constants.ModManifestFileName} file at '{basePath}'.");
 
         // Normalize JToken/JValue entries so downstream lookups are simpler
         var keys = _metadata.Keys.ToArray();
@@ -95,7 +96,7 @@ public class ModAssembly
 
     private string GetRequiredMetadataString(string key)
     {
-        return GetMetadataString(key) ?? throw new MissingFieldException($"Required metadata field '{key}' is missing or empty in mod_meta.json for '{BasePathFolderName}'.");
+        return GetMetadataString(key) ?? throw new MissingFieldException($"Required metadata field '{key}' is missing or empty in {Constants.ModManifestFileName} for '{BasePathFolderName}'.");
     }
 
     private string GetMetadataString(string key)
@@ -280,7 +281,7 @@ public class ModAssembly
 
             if (string.IsNullOrWhiteSpace(depVersion))
             {
-                WinchCore.Log.Warn($"No minimum version specified for dependency '{depName}' in mod {GUID}. Will attempt to load any version of the dependency, but this may cause version conflicts. Specify by appending '@<version>' to the dependency name in mod_meta.json.");
+                WinchCore.Log.Warn($"No minimum version specified for dependency '{depName}' in mod {GUID}. Will attempt to load any version of the dependency, but this may cause version conflicts. Specify by appending '@<version>' to the dependency name in {Constants.ModManifestFileName}.");
             }
 
             bool executed = false;
@@ -318,7 +319,7 @@ public class ModAssembly
     {
         string entrypointSetting = Entrypoint;
         if (!entrypointSetting.Contains("/"))
-            throw new ArgumentException("Malformed Entrypoint in mod_meta.json");
+            throw new ArgumentException($"Malformed Entrypoint in {Constants.ModManifestFileName}");
 
         var parts = entrypointSetting.Split(new[] { '/' }, 2);
         string entrypointTypeName = parts[0];
@@ -343,7 +344,7 @@ public class ModAssembly
     {
         string preloadSetting = Preload;
         if (!preloadSetting.Contains("/"))
-            throw new ArgumentException("Malformed Preload in mod_meta.json");
+            throw new ArgumentException($"Malformed Preload in {Constants.ModManifestFileName}");
 
         var parts = preloadSetting.Split(new[] { '/' }, 2);
         string preloadTypeName = parts[0];

--- a/Winch/Core/ModAssembly.cs
+++ b/Winch/Core/ModAssembly.cs
@@ -102,16 +102,16 @@ public class ModAssembly
         string winchVer = VersionUtil.GetVersion();
 
         if (minVer.IsNullOrWhitespace())
-            WinchCore.Log.Warn($"No MinWinchVersion defined for mod {GUID}. Current Winch version is ({winchVer}). Mod will load anyway, but version conflicts may occur!");
+            WinchCore.Log.Warn($"No MinWinchVersion defined for mod '{GUID}'. Current Winch version is ({winchVer}). Mod will load anyway, but version conflicts may occur!");
         else
         {
             if (!VersionUtil.ValidateVersion(minVer))
-                throw new FormatException($"MinWinchVersion ({minVer}) not in correct format for mod {GUID}.");
+                throw new FormatException($"MinWinchVersion ({minVer}) not in correct format for mod '{GUID}'.");
 
-            WinchCore.Log.Debug($"Mod {GUID} requires Winch version ({minVer}) or newer. Current Winch version is ({winchVer}).");
+            WinchCore.Log.Debug($"Mod '{GUID}' requires Winch ({minVer})+; current ({winchVer}).");
 
             if (!VersionUtil.IsSameOrNewer(winchVer, minVer))
-                throw new Exception($"Mod {GUID} requires Winch version ({minVer}) or newer, but the current Winch version is ({winchVer}). Please update Winch or the mod.");
+                throw new Exception($"Mod '{GUID}' requires Winch version ({minVer}) or newer, but the current Winch version is ({winchVer}). Please update Winch or the mod.");
         }
     }
 

--- a/Winch/Core/ModAssemblyLoader.cs
+++ b/Winch/Core/ModAssemblyLoader.cs
@@ -30,7 +30,17 @@ public static class ModAssemblyLoader
             Directory.CreateDirectory(Paths.ModsPath);
         }
 
-        string[] modDirs = Directory.GetDirectories(Paths.ModsPath);
+        // Find mod metadata files (mod_meta.json) and load mods from their containing folders
+        string[] metaFiles = Directory.Exists(Paths.ModsPath)
+            ? Directory.GetFiles(Paths.ModsPath, "mod_meta.json", SearchOption.AllDirectories)
+            : Array.Empty<string>();
+
+        string[] modDirs = metaFiles
+            .Select(f => Path.GetDirectoryName(f))
+            .Where(d => !string.IsNullOrEmpty(d))
+            .Distinct()
+            .ToArray();
+
         WinchCore.Log.Info($"Loading {modDirs.Length} mod assemblies...");
         foreach (string modDir in modDirs)
         {

--- a/Winch/Core/ModAssemblyLoader.cs
+++ b/Winch/Core/ModAssemblyLoader.cs
@@ -84,27 +84,27 @@ public static class ModAssemblyLoader
         if (LoadedMods.Contains(modName))
             return true;
 
-        if (!EnabledModAssemblies.ContainsKey(modName))
+        if (!_installedAssemblies.ContainsKey(modName))
         {
             ErrorMods.Add(modName);
-            WinchCore.Log.Error($"Mod not loaded: {modName}");
+            WinchCore.Log.Error($"Mod '{modName}' not installed.");
             return false;
         }
 
-        if(minVersion != null)
+        if (!EnabledModAssemblies.ContainsKey(modName))
+        {
+            ErrorMods.Add(modName);
+            WinchCore.Log.Error($"Mod '{modName}' disabled.");
+            return false;
+        }
+
+        if (minVersion != null)
         {
             if (!VersionUtil.IsSameOrNewer(EnabledModAssemblies[modName].Version, minVersion))
             {
                 WinchCore.Log.Error($"Cannot satisfy minimum version constraint {minVersion} for {modName}");
                 return false;
             }
-        }
-
-        var modGUID = EnabledModAssemblies[modName].GUID;
-        if (!EnabledMods[modGUID])
-        {
-            WinchCore.Log.Info($"Mod '{modName}' disabled.");
-            return false;
         }
 
         ModAssemblyLoader.ForceModContext(EnabledModAssemblies[modName]);

--- a/Winch/Core/ModAssemblyLoader.cs
+++ b/Winch/Core/ModAssemblyLoader.cs
@@ -51,6 +51,15 @@ public static class ModAssemblyLoader
         try
         {
             ModAssembly mod = ModAssembly.FromPath(path);
+
+            // Check for duplicate GUID
+            if (_installedAssemblies.Values.Any(m => m.GUID == mod.GUID))
+            {
+                WinchCore.Log.Error($"Cannot load mod '{modName}': another mod with GUID '{mod.GUID}' is already loaded.");
+                ErrorMods.Add(modName);
+                return;
+            }
+
             mod.LoadAssembly();
             _installedAssemblies.Add(modName, mod);
         }

--- a/Winch/Core/ModAssemblyLoader.cs
+++ b/Winch/Core/ModAssemblyLoader.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using Winch.Config;
 using Winch.Util;
+using Winch;
 
 namespace Winch.Core;
 
@@ -32,7 +33,7 @@ public static class ModAssemblyLoader
 
         // Find mod metadata files (mod_meta.json) and load mods from their containing folders
         string[] metaFiles = Directory.Exists(Paths.ModsPath)
-            ? Directory.GetFiles(Paths.ModsPath, "mod_meta.json", SearchOption.AllDirectories)
+            ? Directory.GetFiles(Paths.ModsPath, Constants.ModManifestFileName, SearchOption.AllDirectories)
             : Array.Empty<string>();
 
         string[] modDirs = metaFiles
@@ -139,13 +140,13 @@ public static class ModAssemblyLoader
     {
         try
         {
-            string modListPath = Path.Combine(Paths.WinchRootPath, "mod_list.json");
+            string modListPath = Paths.ModListPath;
 
             if (File.Exists(modListPath))
             {
                 string modList = File.ReadAllText(modListPath);
                 EnabledMods = JsonConvert.DeserializeObject<Dictionary<string, bool>>(modList)
-                              ?? throw new InvalidOperationException("Unable to parse mod_list.json file.");
+                              ?? throw new InvalidOperationException($"Unable to parse {Constants.ModListFileName} file.");
             }
 
             foreach (string mod in _installedAssemblies.Keys)

--- a/Winch/Core/ModAssemblyLoader.cs
+++ b/Winch/Core/ModAssemblyLoader.cs
@@ -94,7 +94,10 @@ public static class ModAssemblyLoader
         if(minVersion != null)
         {
             if (!VersionUtil.IsSameOrNewer(EnabledModAssemblies[modName].Version, minVersion))
-                throw new Exception($"Cannot satisfy minimum version constraint {minVersion} for {modName}");
+            {
+                WinchCore.Log.Error($"Cannot satisfy minimum version constraint {minVersion} for {modName}");
+                return false;
+            }
         }
 
         var modGUID = EnabledModAssemblies[modName].GUID;

--- a/Winch/Core/ModAssemblyLoader.cs
+++ b/Winch/Core/ModAssemblyLoader.cs
@@ -20,7 +20,7 @@ public static class ModAssemblyLoader
 
     static ModAssemblyLoader()
     {
-        ModConfig.GetRelevantModName = GetCurrentModFolderName;
+        ModConfig.GetRelevantModName = GetCurrentModGUID;
     }
 
     internal static void LoadModAssemblies()
@@ -185,9 +185,9 @@ public static class ModAssemblyLoader
         return ReflectionUtil.GetRelevantModAssembly();
     }
 
-    internal static string GetCurrentModFolderName()
+    internal static string GetCurrentModGUID()
     {
-        return GetCurrentMod()?.BasePathFolderName ?? string.Empty;
+        return GetCurrentMod()?.GUID ?? string.Empty;
     }
 
     /// <summary>

--- a/Winch/Core/ModAssemblyLoader.cs
+++ b/Winch/Core/ModAssemblyLoader.cs
@@ -160,8 +160,8 @@ public static class ModAssemblyLoader
     /// <summary>
     /// Get an <see cref="ModAssembly"/> instance from a Mod GUID
     /// </summary>
-    /// <param name="id">The ModGUID</param>
-    /// <returns>The corresponding <see cref="ModAssembly"/>, or null</returns>
+    /// <param name="id">The GUID of the <see cref="ModAssembly"/> you are getting.</param>
+    /// <returns>The corresponding <see cref="ModAssembly"/>, or null if not found</returns>
     internal static ModAssembly? GetMod(string id)
     {
         return _installedAssemblies.TryGetValue(id, out var mod) ? mod : null;
@@ -169,12 +169,22 @@ public static class ModAssemblyLoader
 
     internal static Assembly[] GetAssemblies()
     {
-        return _installedAssemblies.Values.Select(x => x.LoadedAssembly).WhereNotNull().ToArray();
+        return _installedAssemblies.Values
+            .Select(x => x?.LoadedAssembly)
+            .WhereNotNull()
+            .ToArray();
     }
 
-    internal static ModAssembly GetModForAssembly(Assembly a)
+    internal static Assembly? GetAssemblyForMod(string modGUID)
     {
-        return _installedAssemblies.Values.FirstOrDefault((x) => x.LoadedAssembly != null && x.LoadedAssembly == a);
+        if (string.IsNullOrEmpty(modGUID)) return null;
+        return _installedAssemblies.TryGetValue(modGUID, out var mod) ? mod?.LoadedAssembly : null;
+    }
+
+    internal static ModAssembly? GetModForAssembly(Assembly a)
+    {
+        if (a == null) return null;
+        return _installedAssemblies.Values.FirstOrDefault(x => x?.LoadedAssembly != null && x.LoadedAssembly == a);
     }
 
     /// <summary>
@@ -184,6 +194,7 @@ public static class ModAssemblyLoader
     /// <returns>Whether any enabled mod matches the given <paramref name="modGUID"/></returns>
     public static bool IsModEnabled(string modGUID)
     {
+        if (string.IsNullOrEmpty(modGUID)) return false;
         return EnabledModAssemblies.ContainsKey(modGUID);
     }
 

--- a/Winch/Core/ModAssemblyLoader.cs
+++ b/Winch/Core/ModAssemblyLoader.cs
@@ -47,7 +47,7 @@ public static class ModAssemblyLoader
     private static void RegisterModAssembly(string path)
     {
         string modName = Path.GetFileName(path);
-        WinchCore.Log.Debug($"Loading '{modName}'...");
+        WinchCore.Log.Debug($"Loading mod '{modName}' at [{path}]");
         try
         {
             ModAssembly mod = ModAssembly.FromPath(path);

--- a/Winch/Core/Paths.cs
+++ b/Winch/Core/Paths.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Linq;
+using Winch;
 
 namespace Winch.Core;
 
@@ -44,6 +45,11 @@ public static class Paths
     public static string ModsPath { get; private set; }
 
     /// <summary>
+    /// The path to the mod list file which resides in the game root folder.
+    /// </summary>
+    public static string ModListPath { get; private set; }
+
+    /// <summary>
     /// The name of the currently executing process.
     /// </summary>
     public static string ProcessName { get; private set; }
@@ -78,7 +84,9 @@ public static class Paths
 
         ManagedPath = managedPath ?? Path.Combine(GameDataPath, "Managed");
 
-        ModsPath = Path.Combine(WinchRootPath, "Mods");
+        ModsPath = Path.Combine(WinchRootPath, Constants.ModsFolderName);
+
+        ModListPath = Path.Combine(WinchRootPath, Constants.ModListFileName);
 
         DllSearchPaths = (dllSearchPath ?? new string[0]).Concat(new[] { ManagedPath }).Distinct().ToArray();
 

--- a/Winch/Core/WinchBehaviour.cs
+++ b/Winch/Core/WinchBehaviour.cs
@@ -52,6 +52,7 @@ internal class WinchBehaviour : USingleton<WinchBehaviour>
     private void OnGameLoaded()
     {
         WinchCore.Log.Debug("[WinchBehaviour] OnGameLoaded()");
+        DockUtil.AddShipwrightMaterialsTab();
     }
 
     private void OnGameStartable()

--- a/Winch/Core/WinchCore.cs
+++ b/Winch/Core/WinchCore.cs
@@ -63,6 +63,7 @@ public static class WinchCore
             Log.Debug($"Game executable path: {Paths.ExecutablePath}");
             Log.Debug($"Unity Managed directory: {Paths.ManagedPath}");
             Log.Debug($"Winch path: {Paths.WinchPath}");
+            Log.Debug($"Mods path: {Paths.ModsPath}");
         }
         catch (Exception e)
         {

--- a/Winch/Core/WinchCore.cs
+++ b/Winch/Core/WinchCore.cs
@@ -36,15 +36,15 @@ public static class WinchCore
     {
         try
         {
-            string metaPath = Path.Combine(WinchInstallLocation, "mod_meta.json");
+            string metaPath = Path.Combine(WinchInstallLocation, Constants.ModManifestFileName);
             if (!File.Exists(metaPath))
             {
-                throw new FileNotFoundException($"Missing mod_meta.json file for Winch at {metaPath}. Reinstall the mod.");
+                throw new FileNotFoundException($"Missing {Constants.ModManifestFileName} file for Winch at {metaPath}. Reinstall the mod.");
             }
 
             string metaText = File.ReadAllText(metaPath);
             WinchModConfig = JsonConvert.DeserializeObject<Dictionary<string, object>>(metaText)
-                             ?? throw new InvalidOperationException($"Unable to parse mod_meta.json file at {metaPath}. Reinstall the mod.");
+                             ?? throw new InvalidOperationException($"Unable to parse {Constants.ModManifestFileName} file at {metaPath}. Reinstall the mod.");
 
             JSONConfig.AddDynamicConverter(new SerializedCrabPotPOIConverter());
         }

--- a/Winch/Patches/ModsButtonPatcher.cs
+++ b/Winch/Patches/ModsButtonPatcher.cs
@@ -319,8 +319,8 @@ internal static class ModsButtonPatcher
     [HarmonyPatch(typeof(SettingsDialog), nameof(SettingsDialog.ForceSliderFocusExit))]
     public static void SettingsDialog_ForceSliderFocusExit_Prefix(SettingsDialog __instance)
     {
-        if (activeSlider != null) activeSlider.ForceSliderDeselect();
-        if (activeField != null) activeField.ForceSliderDeselect();
+        if (activeSlider != null) activeSlider.ForceDeselect();
+        if (activeField != null) activeField.ForceDeselect();
     }
 
     [HarmonyPrefix]

--- a/Winch/Patches/ModsButtonPatcher.cs
+++ b/Winch/Patches/ModsButtonPatcher.cs
@@ -51,13 +51,13 @@ internal static class ModsButtonPatcher
             scrollbarRect.offsetMax = new Vector2(scrollbarRect.offsetMax.x, otherScroller.offsetMax.y);
             var modsHeader = controlsTabbedPanel.panel.container.transform.Find("ControlEntriesHeader").Instantiate(modsPanel.container.transform, false).Rename("Header");
             modsHeader.DestroyAllChildrenImmediate(0);
-            var headerText = modsHeader.Find("ActionLabel").Rename("Label").gameObject;
+            var headerText = modsHeader.Find("ActionLabel").Rename("LabelLocalized").gameObject;
             var headerTextLocalized = headerText.Instantiate(headerText.transform.parent, false).gameObject.AddComponent<LocalizedLabel>();
             var labelLocalized = headerTextLocalized.Instantiate(prefabs, false);
             labelLocalized.gameObject.Activate();
             var headerTextUnlocalized = headerText.AddComponent<Label>();
             var label = headerTextUnlocalized.Instantiate(prefabs, false);
-            label.gameObject.Activate();
+            label.gameObject.Rename("LabelUnlocalized").Activate();
             controlsTabbedPanel.panel.container.transform.Find("Image").Instantiate(modsPanel.container.transform, false).Rename("ScrollerTopImage");
             controlsTabbedPanel.panel.container.transform.Find("ScrollerBottomImage").Instantiate(modsPanel.container.transform, false);
             var modsFooter = controlsTabbedPanel.panel.container.transform.Find("Footers").Instantiate(modsPanel.container.transform, false).Rename("Footer");
@@ -104,6 +104,8 @@ internal static class ModsButtonPatcher
             modsTab.labelLocalizedPrefab = labelLocalized;
 
             var dropdownInput = modsTab.dropdownPrefab = generalTabbedPanel.panel.container.GetComponentsInChildren<DropdownSettingInput>(true).Where(dsi => dsi.HasComponent<LanguageSelectorDropdown>()).FirstOrDefault().gameObject.Instantiate(prefabs, false).Rename("Dropdown").AddComponent<DropdownInput>();
+            var dropdownContainerRect = dropdownInput.GetComponent<RectTransform>();
+            dropdownInput.transform.localPosition = Vector3.zero;
             dropdownInput.gameObject.RemoveComponentImmediate<LanguageSelectorDropdown>();
             var dropdownOld = dropdownInput.GetComponent<DropdownSettingInput>();
             dropdownInput.dropdown = dropdownOld.dropdown;
@@ -121,6 +123,7 @@ internal static class ModsButtonPatcher
             dropdownInput.gameObject.Activate();
 
             var colorDropdownInput = modsTab.colorDropdownPrefab = generalTabbedPanel.panel.transform.parent.GetComponentInChildren<ColorDropdown>(true).gameObject.Instantiate(prefabs, false).Rename("ColorDropdown").AddComponent<ColorDropdownInput>();
+            colorDropdownInput.transform.localPosition = Vector3.zero;
             colorDropdownInput.gameObject.RemoveComponentImmediate<LanguageSelectorDropdown>();
             var colorDropdownOld = colorDropdownInput.GetComponent<DropdownSettingInput>();
             var colorOld = colorDropdownInput.GetComponent<ColorDropdown>();
@@ -142,6 +145,7 @@ internal static class ModsButtonPatcher
             colorDropdownInput.gameObject.Activate();
 
             var ooDropdownInput = modsTab.onOffDropdownPrefab = generalTabbedPanel.panel.container.GetComponentsInChildren<DropdownSettingInput>(true).Where(dsi => dsi.HasComponent<LanguageSelectorDropdown>()).FirstOrDefault().gameObject.Instantiate(prefabs, false).Rename("OnOffDropdown").AddComponent<OnOffDropdownInput>();
+            ooDropdownInput.transform.localPosition = Vector3.zero;
             ooDropdownInput.gameObject.RemoveComponentImmediate<LanguageSelectorDropdown>();
             var ooDropdownOld = ooDropdownInput.GetComponent<DropdownSettingInput>();
             ooDropdownInput.dropdown = ooDropdownOld.dropdown;
@@ -159,6 +163,7 @@ internal static class ModsButtonPatcher
             ooDropdownInput.gameObject.Activate();
 
             var sliderInput = modsTab.sliderPrefab = generalTabbedPanel.panel.transform.parent.GetComponentInChildren<SliderSettingInput>(true).gameObject.Instantiate(prefabs, false).Rename("Slider").AddComponent<SliderInput>();
+            sliderInput.transform.localPosition = Vector3.zero;
             sliderInput.gameObject.RemoveComponentImmediate<SKUSpecificLocalizedString>();
             var sliderOld = sliderInput.GetComponent<SliderSettingInput>();
             sliderInput.slider = sliderOld.slider;
@@ -172,16 +177,62 @@ internal static class ModsButtonPatcher
             sliderInput.gameObject.Activate();
 
             var inputFieldContainer = modsTab.inputFieldPrefab = modsTab.sliderPrefab.gameObject.Instantiate(prefabs, false).Rename("InputField").AddComponent<FieldInput>(); // TODO: Make these input fields a little better on controller
+            var inputFieldRect = inputFieldContainer.GetComponent<RectTransform>();
+            inputFieldRect.anchorMin = dropdownContainerRect.anchorMin;
+            inputFieldRect.anchorMax = dropdownContainerRect.anchorMax;
+            inputFieldRect.pivot = dropdownContainerRect.pivot;
+            inputFieldRect.offsetMin = dropdownContainerRect.offsetMin;
+            inputFieldRect.offsetMax = dropdownContainerRect.offsetMax;
+            inputFieldRect.sizeDelta = dropdownContainerRect.sizeDelta;
+            inputFieldRect.anchoredPosition = dropdownContainerRect.anchoredPosition;
             inputFieldContainer.gameObject.RemoveComponentImmediate<LanguageSelectorDropdown>();
             var inputFieldOld = inputFieldContainer.GetComponent<SliderInput>();
-            inputFieldContainer.localizedStringField = inputFieldOld.localizedStringField;
+            inputFieldOld.localizedStringField.gameObject.DestroyImmediate();
+            var dropdownLabelContainer = dropdownInput.gameObject.FindChildWithExactName("LabelContainer");
+            var clonedLabelContainer = dropdownLabelContainer.Instantiate(inputFieldContainer.transform, false).Rename("LabelContainer");
+            clonedLabelContainer.transform.SetAsFirstSibling();
+            var clonedLabel = clonedLabelContainer.FindChildWithExactName("DropdownLabel");
+            clonedLabel.name = "Label";
+            inputFieldContainer.localizedStringField = clonedLabel.GetComponent<LocalizeStringEvent>();
             var inputField = Resources.FindObjectsOfTypeAll<TMPro.TMP_InputField>().FirstOrDefault(inFi => inFi.name == "DetailField").Instantiate(inputFieldContainer.transform, true).Rename("InputField");
             inputField.image.sprite = dropdownInput.dropdown.image.sprite;
             inputField.image.color = dropdownInput.dropdown.image.color;
-            inputField.placeholder.color = dropdownInput.dropdown.itemText.color/2;
-            ((TMP_Text)inputField.placeholder).enableAutoSizing = dropdownInput.dropdown.itemText.enableAutoSizing;
+            var inputFieldPlaceholder = ((TMP_Text)inputField.placeholder);
+            inputFieldPlaceholder.color = dropdownInput.dropdown.itemText.color/2;
+            inputFieldPlaceholder.enableAutoSizing = dropdownInput.dropdown.itemText.enableAutoSizing;
             inputField.textComponent.color = dropdownInput.dropdown.itemText.color;
             inputField.textComponent.enableAutoSizing = dropdownInput.dropdown.itemText.enableAutoSizing;
+
+            var inputFontBypass = inputField.textComponent.GetOrAddComponent<LocalizeFontBypass>();
+            inputFontBypass.textField = (TextMeshProUGUI)inputField.textComponent;
+            inputFontBypass.tableString = "Fonts";
+            inputFontBypass.tableEntryString = "DefaultFont";
+            var placeholderFontBypass = inputFieldPlaceholder.GetOrAddComponent<LocalizeFontBypass>();
+            placeholderFontBypass.textField = (TextMeshProUGUI)inputFieldPlaceholder;
+            placeholderFontBypass.tableString = "Fonts";
+            placeholderFontBypass.tableEntryString = "DefaultFont";
+
+
+            inputField.textViewport.anchorMin = dropdownInput.dropdown.captionText.rectTransform.anchorMin;
+            inputField.textViewport.anchorMax = dropdownInput.dropdown.captionText.rectTransform.anchorMax;
+            inputField.textViewport.pivot = dropdownInput.dropdown.captionText.rectTransform.pivot;
+            inputField.textViewport.offsetMin = dropdownInput.dropdown.captionText.rectTransform.offsetMin;
+            inputField.textViewport.offsetMax = dropdownInput.dropdown.captionText.rectTransform.offsetMax;
+            inputField.textViewport.sizeDelta = dropdownInput.dropdown.captionText.rectTransform.sizeDelta;
+            inputField.textViewport.anchoredPosition = dropdownInput.dropdown.captionText.rectTransform.anchoredPosition;
+
+            inputField.textComponent.fontSizeMin = dropdownInput.dropdown.captionText.fontSizeMin;
+            inputField.textComponent.fontSizeMax = dropdownInput.dropdown.captionText.fontSizeMax;
+            inputField.textComponent.alignment = dropdownInput.dropdown.captionText.alignment;
+            inputField.textComponent.extraPadding = dropdownInput.dropdown.captionText.extraPadding;
+            inputField.textComponent.vertexBufferAutoSizeReduction = dropdownInput.dropdown.captionText.vertexBufferAutoSizeReduction;
+
+            inputFieldPlaceholder.fontSizeMin = dropdownInput.dropdown.captionText.fontSizeMin;
+            inputFieldPlaceholder.fontSizeMax = dropdownInput.dropdown.captionText.fontSizeMax;
+            inputFieldPlaceholder.alignment = dropdownInput.dropdown.captionText.alignment;
+            inputFieldPlaceholder.extraPadding = dropdownInput.dropdown.captionText.extraPadding;
+            inputFieldPlaceholder.vertexBufferAutoSizeReduction = dropdownInput.dropdown.captionText.vertexBufferAutoSizeReduction;
+
             inputField.onFocusSelectAll = false;
             inputFieldContainer.inputField = inputField;
             inputField.gameObject.RemoveComponentImmediate<AeLa.EasyFeedback.Utility.TabNext>();
@@ -202,6 +253,7 @@ internal static class ModsButtonPatcher
             ifRect.pivot = dropdownRect.pivot;
             ifRect.offsetMin = dropdownRect.offsetMin;
             ifRect.offsetMax = dropdownRect.offsetMax;
+            ifRect.sizeDelta = dropdownRect.sizeDelta;
             ifRect.anchoredPosition = dropdownRect.anchoredPosition;
             inputFieldOld.slider.gameObject.DestroyImmediate();
             inputFieldOld.DestroyImmediate();

--- a/Winch/Util/BoatUtil.cs
+++ b/Winch/Util/BoatUtil.cs
@@ -355,6 +355,15 @@ public static class BoatUtil
         GameManager.Instance.DialogueRunner.Dialogue.AddOptions(options.ToArray());
     }
 
+    internal static readonly string flagPrefix = "flag-";
+    internal static string RemoveFlagPrefix(string id)
+    {
+        if (string.IsNullOrEmpty(id)) return string.Empty;
+
+        // Substring instead of replace
+        return id.StartsWith(flagPrefix) ? id.Substring(flagPrefix.Length) : id;
+    }
+
     public static string GetIdOfFlagInInventoryAndStorage()
     {
         var allItemsOfType =
@@ -362,7 +371,7 @@ public static class BoatUtil
             .Concat(GameManager.Instance.SaveData.Storage.GetAllItemsOfType<SpatialItemInstance>(ItemType.GENERAL, ItemSubtype.GENERAL))
             .ToItemData();
         var flag = allItemsOfType.FirstOrDefault(item => item is HarvestableItemData harvestableItem && harvestableItem.IsFlag());
-        var id = flag != null ? flag.id.Replace("flag-", "") : string.Empty;
+        var id = flag != null ? RemoveFlagPrefix(flag.id) : string.Empty;
         WinchCore.Log.Debug($"GetIdOfFlagInInventoryAndStorage() returning {id}");
         return id;
     }

--- a/Winch/Util/BoatUtil.cs
+++ b/Winch/Util/BoatUtil.cs
@@ -284,7 +284,7 @@ public static class BoatUtil
     internal static int GetModdedFlagPages()
     {
         var pages = Mathf.CeilToInt(ModdedBoatFlagDataDict.Count / (float)optionsPerPage);
-        WinchCore.Log.Error("GetModdedFlagPages " + pages);
+        WinchCore.Log.Debug("GetModdedFlagPages " + pages);
         return pages;
     }
 
@@ -295,7 +295,7 @@ public static class BoatUtil
 
     internal static void AddModdedFlagPageOptions(int moddedFlagPageNumber)
     {
-        WinchCore.Log.Error("AddModdedFlagPageOptions " + moddedFlagPageNumber);
+        WinchCore.Log.Debug("AddModdedFlagPageOptions " + moddedFlagPageNumber);
         List<DialogueUtil.DredgeOption> options = new List<DialogueUtil.DredgeOption>();
         foreach (BoatFlagData flagData in GetFlagsForModdedPage(moddedFlagPageNumber))
         {
@@ -331,7 +331,7 @@ public static class BoatUtil
     internal static int GetModdedPaintPages()
     {
         var pages = Mathf.CeilToInt(ModdedBoatPaintDataDict.Count / (float)optionsPerPage);
-        WinchCore.Log.Error("GetModdedPaintPages " + pages);
+        WinchCore.Log.Debug("GetModdedPaintPages " + pages);
         return pages;
     }
 
@@ -342,7 +342,7 @@ public static class BoatUtil
 
     internal static void AddModdedPaintPageOptions(int moddedColorPageNumber)
     {
-        WinchCore.Log.Error("AddModdedPaintPageOptions " + moddedColorPageNumber);
+        WinchCore.Log.Debug("AddModdedPaintPageOptions " + moddedColorPageNumber);
         List<DialogueUtil.DredgeOption> options = new List<DialogueUtil.DredgeOption>();
         foreach (BoatPaintData paintData in GetPaintsForModdedPage(moddedColorPageNumber))
         {

--- a/Winch/Util/BoatUtil.cs
+++ b/Winch/Util/BoatUtil.cs
@@ -362,7 +362,7 @@ public static class BoatUtil
             .Concat(GameManager.Instance.SaveData.Storage.GetAllItemsOfType<SpatialItemInstance>(ItemType.GENERAL, ItemSubtype.GENERAL))
             .ToItemData();
         var flag = allItemsOfType.FirstOrDefault(item => item is HarvestableItemData harvestableItem && harvestableItem.IsFlag());
-        var id = flag != null ? flag.id : string.Empty;
+        var id = flag != null ? flag.id.Replace("flag-", "") : string.Empty;
         WinchCore.Log.Debug($"GetIdOfFlagInInventoryAndStorage() returning {id}");
         return id;
     }

--- a/Winch/Util/BoatUtil.cs
+++ b/Winch/Util/BoatUtil.cs
@@ -274,7 +274,11 @@ public static class BoatUtil
         dialogueRunner.AddCommandHandler<string>("ChangeBoatFlag", ChangeBoatFlag);
     }
 
-    public static bool GetHasFlag(string flagId) => GameManager.Instance.SaveData.GetBoolVariable($"has-flag-{flagId}");
+    public static bool GetHasFlag(string flagId) {
+        var result = GameManager.Instance.SaveData.GetBoolVariable($"has-flag-{flagId}");
+        WinchCore.Log.Debug($"GetHasFlag({flagId}) returning {result}");
+        return result;
+    }
     public static void SetHasFlag(string flagId, bool hasFlag) => GameManager.Instance.SaveData.SetBoolVariable($"has-flag-{flagId}", hasFlag);
 
     internal static int GetModdedFlagPages()

--- a/Winch/Util/DockUtil.cs
+++ b/Winch/Util/DockUtil.cs
@@ -947,4 +947,27 @@ public static class DockUtil
         vcam.AddCinemachineComponent<CinemachineComposer>();
         return vcam;
     }
+
+    internal static void AddShipwrightMaterialsTab()
+    {
+        try
+        {
+            var shipwright = GetAllShipyardDestinations().FirstOrDefault(shipyard => shipyard.name == "Shipwright");
+            shipwright.marketTabs.Add(new MarketTabConfig
+            {
+                gridKey = GridKey.SHIPWRIGHT_MATERIALS,
+                tabSprite = TextureUtil.GetSprite("JunkIcon"),
+                titleKey = LocalizationUtil.CreateStringsReference("title.shipwright-materials"),
+                isUnlockedBasedOnDialogue = false,
+                unlockDialogueNodes = new List<string>()
+            });
+            shipwright.itemSubtypesBought |= ItemSubtype.GENERAL;
+            shipwright.itemSubtypesBought |= ItemSubtype.MATERIAL;
+
+        }
+        catch (Exception ex)
+        {
+            WinchCore.Log.Error($"Failed to add Shipwright Materials tab: {ex}");
+        }
+    }
 }

--- a/Winch/mod_meta.json
+++ b/Winch/mod_meta.json
@@ -2,5 +2,5 @@
 	"Name": "Winch",
 	"Author": "Hacktix",
 	"ModGUID": "hacktix.winch",
-	"Version": "0.6.1"
+	"Version": "0.6.2"
 }

--- a/WinchCommon/Config/ModConfig.cs
+++ b/WinchCommon/Config/ModConfig.cs
@@ -31,7 +31,7 @@ public class ModConfig : JSONConfig
             return path;
         else
         {
-            //WinchCore.Log.Error($"No 'DefaultConfig' attribute found in mod_meta.json for {modName}!");
+            //WinchCore.Log.Error($"No 'DefaultConfig' attribute found in {Constants.ModManifestFileName} for {modName}!");
             throw new KeyNotFoundException($"No '{Constants.ModDefaultConfigFileName}' file found in folder for {modName}!");
         }
     }

--- a/WinchCommon/Config/ModConfig.cs
+++ b/WinchCommon/Config/ModConfig.cs
@@ -5,6 +5,7 @@ namespace Winch.Config;
 public class ModConfig : JSONConfig
 {
     private static Dictionary<string, string> DefaultConfigs = new Dictionary<string, string>();
+    private static Dictionary<string, string> BasePaths = new Dictionary<string, string>();
     private static Dictionary<string, ModConfig> Instances = new Dictionary<string, ModConfig>();
 
     private ModConfig(string path, string defaultPath) : base(path, defaultPath)
@@ -38,6 +39,8 @@ public class ModConfig : JSONConfig
     private static string GetBasePath(string modName)
     {
         if (string.IsNullOrWhiteSpace(modName)) throw new ArgumentNullException("modName");
+
+        if (BasePaths.TryGetValue(modName, out var basePath)) return basePath;
 
         return Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Mods", modName);
     }
@@ -153,5 +156,12 @@ public class ModConfig : JSONConfig
     {
         if (string.IsNullOrWhiteSpace(config)) throw new ArgumentNullException("config");
         DefaultConfigs.Add(modName, config);
+    }
+
+    internal static void RegisterBasePath(string modName, string basePath)
+    {
+        if (string.IsNullOrWhiteSpace(basePath)) throw new ArgumentNullException("basePath");
+        if (BasePaths.ContainsKey(modName)) return;
+        BasePaths.Add(modName, basePath);
     }
 }

--- a/WinchCommon/Config/default_config.json
+++ b/WinchCommon/Config/default_config.json
@@ -4,7 +4,7 @@
 	"LogLevel": "DEBUG",
 	"LogsFolder": "Logs",
 	"DetailedLogSources": false,
-	"EnableDeveloperConsole": true,
+	"EnableDeveloperConsole": false,
 	"MaxLogFiles": 10,
 	"ExportYarnProgram": false,
 	"LogPort": ""

--- a/WinchCommon/Constants.cs
+++ b/WinchCommon/Constants.cs
@@ -9,6 +9,10 @@ public static class Constants
 {
 	public const string IP = "127.0.0.1";
 
+	public const string WinchTitle = "Winch";
+
+	public const string ModsFolderName = "Mods";
+
 	public const string WinchConfigFileName = "WinchConfig.json";
 
 	public const string WinchDefaultConfigFileName = "WinchDefaultConfig.json";
@@ -18,6 +22,8 @@ public static class Constants
 	public const string ModDefaultConfigFileName = "default_config.json";
 
 	public const string ModManifestFileName = "mod_meta.json";
+
+	public const string ModListFileName = "mod_list.json";
 
 	internal const string OldModConfigFileName = "Config.json";
 

--- a/WinchCommon/Properties/Resources.Designer.cs
+++ b/WinchCommon/Properties/Resources.Designer.cs
@@ -67,7 +67,7 @@ namespace Winch.Properties {
         ///	&quot;LogLevel&quot;: &quot;DEBUG&quot;,
         ///	&quot;LogsFolder&quot;: &quot;Logs&quot;,
         ///	&quot;DetailedLogSources&quot;: false,
-        ///	&quot;EnableDeveloperConsole&quot;: true,
+        ///	&quot;EnableDeveloperConsole&quot;: false,
         ///	&quot;MaxLogFiles&quot;: 10,
         ///	&quot;ExportYarnProgram&quot;: false,
         ///	&quot;LogPort&quot;: &quot;&quot;


### PR DESCRIPTION
## Winch v0.6.2
- Improved dependency processor logging. (Fixes #15)
- Simplified mod assemblies and related systems.
- Disabled dev console by default and added controller note. (Fixes #24)
- Fixed duplicate mod registration errors.
- Fixed vanilla flag ID handling. (Fixes #43)
- Fixed options not updating in mod tabs. (Fixes #46)
- Attempt to fix field inputs in mod settings looking weird on some computers. (Resolves #45)
- Added shipwright materials tab.

## Example Items v2.0.2
- Added a harvest POI with a vanilla particle.
- Added config example.